### PR TITLE
Change snyk script from prepare to prepublishOnly

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "test:coverage": "nwb test-react --coverage",
     "test:watch": "nwb test-react --server",
     "snyk-protect": "snyk protect",
-    "prepare": "npm run snyk-protect"
   },
   "dependencies": {
     "react": "^18.0.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "nwb test-react",
     "test:coverage": "nwb test-react --coverage",
     "test:watch": "nwb test-react --server",
-    "snyk-protect": "snyk protect",
+    "snyk-protect": "snyk protect"
   },
   "dependencies": {
     "react": "^18.0.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "nwb test-react",
     "test:coverage": "nwb test-react --coverage",
     "test:watch": "nwb test-react --server",
-    "snyk-protect": "snyk protect"
+    "snyk-protect": "snyk protect",
+    "prepublishOnly": "npm run snyk-protect"
   },
   "dependencies": {
     "react": "^18.0.0",


### PR DESCRIPTION
This is on top of Duncan's webpack changes (#510) because it would be best for this to be included in the `v1.0.0` release

Having the `snyk` script run in a `prepare` script is a problem when projects using yarn use a git-branch specific version of `django-react-loader`. In this case the npm will install `django-react-loader` dependencies and run the script, generating a `package-lock.json`, which will then cause problems for the parent project. `snyk protect` only needs to be run before publishing the package, so `prepublishOnly` is more appropriate

Descriptions of `prepare` vs `prepublishOnly` are in the [npm docs](https://docs.npmjs.com/cli/v10/using-npm/scripts)

